### PR TITLE
feat: add external dns

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -3,7 +3,7 @@ name: air.stacks-infrastructure-eks
 on:
   push:
     branches:
-      - feat/external-dns
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -75,6 +75,11 @@ env:
   CERT_MANAGER_SERVICE_ACCOUNT_NAME: "cert-manager"
   CERT_MANAGER_EMAIL_ADDRESS: "stacks@ensono.com"
 
+  # External DNS Helm
+  EXTERNAL_DNS_ENABLED: true
+  EXTERNAL_DNS_NAMESPACE: "external-dns"
+  EXTERNAL_DNS_SERVICE_ACCOUNT_NAME: "external-dns"
+
 jobs:
   Lint:
     runs-on: ubuntu-24.04
@@ -169,6 +174,9 @@ jobs:
           TF_VAR_cert_manager_enabled: "${{ env.CERT_MANAGER_ENABLED }}"
           TF_VAR_cert_manager_namespace: "${{ env.CERT_MANAGER_NAMESPACE }}"
           TF_VAR_cert_manager_service_account_name: "${{ env.CERT_MANAGER_SERVICE_ACCOUNT_NAME }}"
+          TF_VAR_external_dns_enabled: "${{ env.EXTERNAL_DNS_ENABLED }}"
+          TF_VAR_external_dns_namespace: "${{ env.EXTERNAL_DNS_NAMESPACE }}"
+          TF_VAR_external_dns_service_account_name: "${{ env.EXTERNAL_DNS_SERVICE_ACCOUNT_NAME }}"
 
       - name: Helm Deploy
         run: taskctl helm
@@ -253,6 +261,9 @@ jobs:
           TF_VAR_cert_manager_enabled: "${{ env.CERT_MANAGER_ENABLED }}"
           TF_VAR_cert_manager_namespace: "${{ env.CERT_MANAGER_NAMESPACE }}"
           TF_VAR_cert_manager_service_account_name: "${{ env.CERT_MANAGER_SERVICE_ACCOUNT_NAME }}"
+          TF_VAR_external_dns_enabled: "${{ env.EXTERNAL_DNS_ENABLED }}"
+          TF_VAR_external_dns_namespace: "${{ env.EXTERNAL_DNS_NAMESPACE }}"
+          TF_VAR_external_dns_service_account_name: "${{ env.EXTERNAL_DNS_SERVICE_ACCOUNT_NAME }}"
 
       - name: Helm Deploy
         run: taskctl helm

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -3,7 +3,7 @@ name: air.stacks-infrastructure-eks
 on:
   push:
     branches:
-      - main
+      - feat/external-dns
   pull_request:
     branches:
       - main

--- a/deploy/aws/infra/.terraform.lock.hcl
+++ b/deploy/aws/infra/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.58.0"
-  constraints = ">= 4.33.0, >= 5.0.0, ~> 5.0, >= 5.58.0"
+  version     = "5.63.0"
+  constraints = ">= 4.33.0, >= 5.0.0, ~> 5.0, >= 5.61.0"
   hashes = [
-    "h1:J0JP487E7DfMLr1R5s9g9HfeDaKu2E8KaZv6MlhVVi4=",
-    "zh:15e9be54a8febe8e560362b10967cb60b680ca3f78fe207d7209b76e076f59d3",
-    "zh:240f6899a2cec259aa2729ce031f6af2b453f90a8b59118bb2571c54acc65db8",
-    "zh:2b6e8e2ab1a3dce1001503dba6086a128bb2a71652b0d0b3b107db665b7d6881",
-    "zh:579b0ed95247a0bd8bfb3fac7fb767547dde76026c578f4f184b5743af5e32cc",
-    "zh:6adcd10fd12be0be9eb78a89e745a5b77ae0d8b3522cd782456a71178aad8ccb",
-    "zh:7f829cef82f0a02faa97d0fbe1417a40b73fc5142e883b12eebc5b71015efac9",
-    "zh:81977f001998c9096f7b59710996e159774a9313c1bc03db3beb81c3e016ebef",
+    "h1:jGnSBSPCBaDmu9MCu3eyPJBPCobae2XaFib8OQ2C5OA=",
+    "zh:21f3a6870dd80b8312b6aac28784b29a7c2cf072175f0de943f09bddbf14cad6",
+    "zh:28feb0621baeaa9b6992a6209fd0d7ad1c665b1dd895123f2fd36d91d69d116f",
+    "zh:301d51b398c3e3488ea2b63defeb254436854c83046d9fc5ca129b13faaa4319",
+    "zh:343e89645a2b23363226e2e0571639637ac1ddf7fa8c562bf883b17c8ad30d7d",
+    "zh:56c89148fc105a1bf32ffcd574ec1e679144377ea26c9ae4211dd491a3def358",
+    "zh:5e3b88e3eb28b23819126d43b191a2bda28a09d7690aee7e577b3b6235c4824a",
+    "zh:64c21f3b38a8f0f0ef8b938df71cde76d77e010236bb6a0b46f66daa6cab6f99",
+    "zh:6869e5fafe6535954ac75ece63e9765d6b12d1752b54cf9639a01585f1a5583e",
+    "zh:90a6894868c585a5abf00e784723d74ea80aff3d0403b36028c4b08c5c4894d6",
+    "zh:92e9e4b7c183e518c1decd0fbc780e9f1941d05710c9c20329c78556a7f0adac",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a5d98ac6fab6e6c85164ca7dd38f94a1e44bd70c0e8354c61f7fbabf698957cd",
-    "zh:c27fa4fed50f6f83ca911bef04f05d635a7b7a01a89dc8fc5d66a277588f08df",
-    "zh:d4042bdf86ca6dc10e0cca91c4fcc592b12572d26185b3d37bbbb9e2026ac68b",
-    "zh:d536482cf4ace0d49a2a86c931150921649beae59337d0c02a785879fe943cf3",
-    "zh:e205f8243274a621fb9ef2b5e2c71e84c1670be1d23697739439f5a831fa620f",
-    "zh:eb76ce0c77fd76c47f57122c91c4fcf0f72c01423538ed7833eaa7eeaae2edf6",
-    "zh:ffe04e494af6cc7348ceb8d85f4c1d5a847a44510827b4496513c810a4d9196d",
+    "zh:bbc053d060d4f6e95ef60549a0e92487fbbd88807f8161507cc389edc7dde0f7",
+    "zh:cfd8e88029a2fdafdfa77688f966705ade9211d173cbb6aa1552839c9993c19a",
+    "zh:d291875c26a6a05b60e02f1481c296269080232fa0ae86cce5caa04a6df82ed6",
+    "zh:f42f0b81587de0c51859e37cd671c442d8eaf42558d83c6421b1e46549576f89",
   ]
 }
 
@@ -29,6 +29,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   constraints = ">= 2.0.0, ~> 2.0"
   hashes = [
     "h1:+J2rgfJH5B0vyFR0Wfcoyt4SHWfZLDe+WtUMtmZLDeY=",
+    "h1:S3j8poSaLbaftlKq2STBkQEkZH253ZLaHhBHBifdpBQ=",
     "zh:09f1f1e1d232da96fbf9513b0fb5263bc2fe9bee85697aa15d40bb93835efbeb",
     "zh:381e74b90d7a038c3a8dcdcc2ce8c72d6b86da9f208a27f4b98cabe1a1032773",
     "zh:398eb321949e28c4c5f7c52e9b1f922a10d0b2b073b7db04cb69318d24ffc5a9",
@@ -48,6 +49,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.2"
   constraints = ">= 3.0.0, ~> 3.0"
   hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
     "h1:m467k2tZ9cdFFgHW7LPBK2GLPH43LC6wc3ppxr8yvoE=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
     "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
@@ -68,6 +70,7 @@ provider "registry.terraform.io/hashicorp/time" {
   version     = "0.12.0"
   constraints = ">= 0.9.0, ~> 0.9"
   hashes = [
+    "h1:Os2Ok7txtlUJHh6Hg7o+74Ql85SnRb/fGmah22yXpLw=",
     "h1:S5xl3l6/rQmmujpKsHojuD1bPSo6F44JnlEWaRC03wU=",
     "zh:019a4c09af254ef80b72cf0d843dfe72d99483e227138cf5b514a1b9977ab4c3",
     "zh:0ae310ec740ebc6f275529507d60bb747d0bf39e72fc5a2fa90d74486006132c",
@@ -88,6 +91,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "3.4.0"
   constraints = ">= 3.0.0, ~> 3.0"
   hashes = [
+    "h1:QpJxHEQt5369EnAZ10+8MnvJ0TktFA0oWbRe6lzvb+s=",
     "h1:RS6P09hCyDYlqbK80SlnKMuqYg4MEvw+xyIf9Ca8WPM=",
     "zh:2442a0df0cfb550b8eba9b2af39ac06f54b62447eb369ecc6b1c29f739b33bbb",
     "zh:3ebb82cacb677a099de55f844f0d02886bc804b1a2b94441bc40fabcb64d2a38",

--- a/deploy/aws/infra/iam-eks-external-dns.tf
+++ b/deploy/aws/infra/iam-eks-external-dns.tf
@@ -1,0 +1,42 @@
+data "aws_iam_policy_document" "external_dns" {
+  statement {
+    actions = [
+      "route53:ChangeResourceRecordSets",
+    ]
+
+    resources = [
+      "arn:aws:route53:::hostedzone/*",
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    actions = [
+      "route53:ListHostedZones",
+      "route53:ListResourceRecordSets",
+      "route53:ListTagsForResource",
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    effect = "Allow"
+  }
+}
+
+module "external_dns_irsa_iam_role" {
+  count = var.external_dns_enabled ? 1 : 0
+
+  source = "git::https://github.com/Ensono/stacks-terraform//aws/modules/infrastructure_modules/eks_irsa?ref=v5.0.23"
+
+  cluster_name            = module.default_label.id
+  cluster_oidc_issuer_url = module.eks.cluster_oidc_issuer_url
+  aws_account_id          = local.account_id
+  namespace               = var.external_dns_namespace
+  service_account_name    = var.external_dns_service_account_name
+  resource_description    = "external-dns to add records in Route53 for services"
+  policy                  = data.aws_iam_policy_document.external_dns.json
+  policy_prefix           = var.name_environment
+}

--- a/deploy/aws/infra/outputs.tf
+++ b/deploy/aws/infra/outputs.tf
@@ -65,3 +65,11 @@ output "cert_manager_role_arn" {
   description = "The ARN of the AWS Role created for cert-manager to use"
   value       = module.cert_manager_irsa_iam_role[0].irsa_role_arn
 }
+
+####################
+# External DNS IRSA
+####################
+output "external_dns_role_arn" {
+  description = "The ARN of the AWS Role created for external-dns to use"
+  value       = module.external_dns_irsa_iam_role[0].irsa_role_arn
+}

--- a/deploy/aws/infra/variables.tf
+++ b/deploy/aws/infra/variables.tf
@@ -123,3 +123,22 @@ variable "cert_manager_namespace" {
   type        = string
   description = "The Namespace that Cert Manager will be deployed to"
 }
+
+########################################
+# External DNS IAM IRSA
+########################################
+
+variable "external_dns_enabled" {
+  type        = bool
+  description = "Whether to enable External DNS or not"
+}
+
+variable "external_dns_service_account_name" {
+  type        = string
+  description = "The Kubernetes Service Account name for External DNS"
+}
+
+variable "external_dns_namespace" {
+  type        = string
+  description = "The Namespace that External DNS will be deployed to"
+}

--- a/deploy/helm/k8s_apps.yaml
+++ b/deploy/helm/k8s_apps.yaml
@@ -33,3 +33,11 @@ charts:
     repo: https://kubernetes.github.io/ingress-nginx
     values_template: deploy/helm/values/ingress_nginx.yaml
     version: 4.11.0
+
+  - name: external-dns
+    namespace: external-dns
+    location: external-dns
+    enabled: "${env:EXTERNAL_DNS_ENABLED}"
+    repo: https://charts.bitnami.com/bitnami
+    values_template: deploy/helm/values/external_dns.yaml
+    version: 8.3.5

--- a/deploy/helm/values/external_dns.yaml
+++ b/deploy/helm/values/external_dns.yaml
@@ -12,3 +12,5 @@ serviceAccount:
 
 podSecurityContext:
   fsGroup: 1001
+
+txtOwnerId: "${env:TFOUT_cluster_name}-external-dns"

--- a/deploy/helm/values/external_dns.yaml
+++ b/deploy/helm/values/external_dns.yaml
@@ -7,7 +7,7 @@ env:
 serviceAccount:
   create: true
   name: "${env:EXTERNAL_DNS_SERVICE_ACCOUNT_NAME}"
-  annotations: 
+  annotations:
     eks.amazonaws.com/role-arn: "${env:TFOUT_external_dns_role_arn}"
 
 podSecurityContext:

--- a/deploy/helm/values/external_dns.yaml
+++ b/deploy/helm/values/external_dns.yaml
@@ -1,0 +1,14 @@
+provider: aws
+
+env:
+  - name: AWS_DEFAULT_REGION
+    value: ${env:REGION}
+
+serviceAccount:
+  create: true
+  name: "${env:EXTERNAL_DNS_SERVICE_ACCOUNT_NAME}"
+  annotations: 
+    eks.amazonaws.com/role-arn: "${env:TFOUT_external_dns_role_arn}"
+
+podSecurityContext:
+  fsGroup: 1001


### PR DESCRIPTION
#### 📲 What

Install external-dns via Helm chart 

#### 🤔 Why

So DNS records can be created automatically in Route53.

#### 🛠 How

- Create roles in AWS using Terraform
- Install external-dns via Helm chart

#### 👀 Evidence

Currently deployed to the nonprod Stacks cluster in AWS. The created records can be found in Route53 for the nonprod.aws.stacks.ensono.com hosted zone.

#### 🕵️ How to test

-

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
