### PR TITLE
added ebs csi volume driver chart

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -38,7 +38,7 @@ env:
   NON_PROD_EKS_DESIRED_NODES: "2"
   PROD_EKS_DESIRED_NODES: "1"
   EKS_MAXIMUM_NODES: "3"
-  EKS_NODE_SIZE: "t3.small"
+  EKS_NODE_SIZE: "t3.medium"
 
   CLUSTER_ENDPOINT_PRIVATE_ACCESS: false
   CLUSTER_ENDPOINT_PUBLIC_ACCESS: true
@@ -92,8 +92,7 @@ env:
   KYVERNO_VALIDATION_FAILURE_ACTION: "Audit"
 
   # AWS EBS CSI Driver
-  # Disable this as it is not needed for the default EKS cluster and we do not have enough resources to run it
-  AWS_EBS_CSI_DRIVER_ENABLED: false
+  AWS_EBS_CSI_DRIVER_ENABLED: true
   AWS_EBS_CSI_DRIVER_NAMESPACE: "aws-ebs-csi-driver"
   AWS_EBS_CSI_DRIVER_SERVICE_ACCOUNT_NAME: "aws-ebs-csi-driver"
 

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -92,7 +92,8 @@ env:
   KYVERNO_VALIDATION_FAILURE_ACTION: "Audit"
 
   # AWS EBS CSI Driver
-  AWS_EBS_CSI_DRIVER_ENABLED: true
+  # Disable this as it is not needed for the default EKS cluster and we do not have enough resources to run it
+  AWS_EBS_CSI_DRIVER_ENABLED: false
   AWS_EBS_CSI_DRIVER_NAMESPACE: "aws-ebs-csi-driver"
   AWS_EBS_CSI_DRIVER_SERVICE_ACCOUNT_NAME: "aws-ebs-csi-driver"
 

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -91,6 +91,11 @@ env:
   # Audit or Enforce: Audit will only log the violations, Enforce will block the deployment
   KYVERNO_VALIDATION_FAILURE_ACTION: "Audit"
 
+  # AWS EBS CSI Driver
+  AWS_EBS_CSI_DRIVER_ENABLED: true
+  AWS_EBS_CSI_DRIVER_NAMESPACE: "aws-ebs-csi-driver"
+  AWS_EBS_CSI_DRIVER_SERVICE_ACCOUNT_NAME: "aws-ebs-csi-driver"
+
 jobs:
   Lint:
     runs-on: ubuntu-24.04
@@ -198,6 +203,9 @@ jobs:
           TF_VAR_external_dns_service_account_name: "${{ env.EXTERNAL_DNS_SERVICE_ACCOUNT_NAME }}"
           TF_VAR_bottlerocket_cis_enabled: ${{ env.BOTTLEROCKET_CIS_ENABLED }}
           TF_VAR_bottlerocket_cis_image: "${{ env.BOTTLEROCKET_CIS_BOOTSTRAP_IMAGE }}:${{ env.BOTTLEROCKET_CIS_BOOTSTRAP_TAG }}"
+          TF_VAR_aws-ebs-csi-driver_enabled: "${{ env.AWS_EBS_CSI_DRIVER_ENABLED }}"
+          TF_VAR_aws-ebs-csi-driver_namespace: "${{ env.AWS_EBS_CSI_DRIVER_NAMESPACE }}"
+          TF_VAR_aws-ebs-csi-driver_service_account_name: "${{ env.AWS_EBS_CSI_DRIVER_SERVICE_ACCOUNT_NAME }}"
 
       - name: Helm Deploy
         run: taskctl helm

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -203,9 +203,9 @@ jobs:
           TF_VAR_external_dns_service_account_name: "${{ env.EXTERNAL_DNS_SERVICE_ACCOUNT_NAME }}"
           TF_VAR_bottlerocket_cis_enabled: ${{ env.BOTTLEROCKET_CIS_ENABLED }}
           TF_VAR_bottlerocket_cis_image: "${{ env.BOTTLEROCKET_CIS_BOOTSTRAP_IMAGE }}:${{ env.BOTTLEROCKET_CIS_BOOTSTRAP_TAG }}"
-          TF_VAR_aws-ebs-csi-driver_enabled: "${{ env.AWS_EBS_CSI_DRIVER_ENABLED }}"
-          TF_VAR_aws-ebs-csi-driver_namespace: "${{ env.AWS_EBS_CSI_DRIVER_NAMESPACE }}"
-          TF_VAR_aws-ebs-csi-driver_service_account_name: "${{ env.AWS_EBS_CSI_DRIVER_SERVICE_ACCOUNT_NAME }}"
+          TF_VAR_aws_ebs_csi_driver_enabled: "${{ env.AWS_EBS_CSI_DRIVER_ENABLED }}"
+          TF_VAR_aws_ebs_csi_driver_namespace: "${{ env.AWS_EBS_CSI_DRIVER_NAMESPACE }}"
+          TF_VAR_aws_ebs_csi_driver_service_account_name: "${{ env.AWS_EBS_CSI_DRIVER_SERVICE_ACCOUNT_NAME }}"
 
       - name: Helm Deploy
         run: taskctl helm

--- a/deploy/aws/infra/iam-eks-aws-ebs-csi-driver.tf
+++ b/deploy/aws/infra/iam-eks-aws-ebs-csi-driver.tf
@@ -1,0 +1,18 @@
+data "aws_iam_policy" "ebs_csi_policy" {
+  arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+module "ebs_csi_irsa_iam_role" {
+  count = var.aws_ebs_csi_driver_enabled ? 1 : 0
+
+  source = "git::https://github.com/Ensono/stacks-terraform//aws/modules/infrastructure_modules/eks_irsa?ref=v6.0.31"
+
+  cluster_name            = module.default_label.id
+  cluster_oidc_issuer_url = module.eks.cluster_oidc_issuer_url
+  aws_account_id          = local.account_id
+  namespace               = var.aws_ebs_csi_driver_namespace
+  service_account_name    = var.aws_ebs_csi_driver_service_account_name
+  resource_description    = "IAM permissions for Amazon EBS CSI Driver to talk to Amazon EBS to manage volumes"
+  policy                  = data.aws_iam_policy.ebs_csi_policy.policy
+  policy_prefix           = var.name_environment
+}

--- a/deploy/aws/infra/outputs.tf
+++ b/deploy/aws/infra/outputs.tf
@@ -63,7 +63,7 @@ output "cluster_oidc_provider_arn" {
 ####################
 output "cert_manager_role_arn" {
   description = "The ARN of the AWS Role created for cert-manager to use"
-  value       = module.cert_manager_irsa_iam_role[0].irsa_role_arn
+  value       = var.cert_manager_enabled ? module.cert_manager_irsa_iam_role[0].irsa_role_arn : null
 }
 
 ####################
@@ -71,7 +71,7 @@ output "cert_manager_role_arn" {
 ####################
 output "external_dns_role_arn" {
   description = "The ARN of the AWS Role created for external-dns to use"
-  value       = module.external_dns_irsa_iam_role[0].irsa_role_arn
+  value       = var.external_dns_enabled ? module.external_dns_irsa_iam_role[0].irsa_role_arn : null
 }
 
 ####################
@@ -79,5 +79,5 @@ output "external_dns_role_arn" {
 ####################
 output "aws_ebs_csi_driver_role_arn" {
   description = "The ARN of the AWS Role created for AWS EBS CSI Driver to use"
-  value       = module.ebs_csi_irsa_iam_role[0].irsa_role_arn
+  value       = var.aws_ebs_csi_driver_enabled ? module.ebs_csi_irsa_iam_role[0].irsa_role_arn : null
 }

--- a/deploy/aws/infra/outputs.tf
+++ b/deploy/aws/infra/outputs.tf
@@ -73,3 +73,12 @@ output "external_dns_role_arn" {
   description = "The ARN of the AWS Role created for external-dns to use"
   value       = module.external_dns_irsa_iam_role[0].irsa_role_arn
 }
+
+
+####################
+# Cert Manager IRSA
+####################
+output "aws_ebs_csi_driver_role_arn" {
+  description = "The ARN of the AWS Role created for AWS EBS CSI Driver to use"
+  value       = module.ebs_csi_irsa_iam_role[0].irsa_role_arn
+}

--- a/deploy/aws/infra/outputs.tf
+++ b/deploy/aws/infra/outputs.tf
@@ -74,7 +74,6 @@ output "external_dns_role_arn" {
   value       = module.external_dns_irsa_iam_role[0].irsa_role_arn
 }
 
-
 ####################
 # Cert Manager IRSA
 ####################

--- a/deploy/aws/infra/variables.tf
+++ b/deploy/aws/infra/variables.tf
@@ -155,3 +155,21 @@ variable "bottlerocket_cis_image" {
   type        = string
   description = "The location of the CIS Bottlerocket image"
 }
+
+########################################
+# AWS EBS CSI Driver IAM IRSA
+########################################
+variable "aws_ebs_csi_driver_enabled" {
+  type        = bool
+  description = "Whether to enable AWS EBS CSI Driver or not"
+}
+
+variable "aws_ebs_csi_driver_service_account_name" {
+  type        = string
+  description = "The Kubernetes Service Account name for AWS EBS CSI Driver"
+}
+
+variable "aws_ebs_csi_driver_namespace" {
+  type        = string
+  description = "The Namespace that AWS EBS CSI Driver will be deployed to"
+}

--- a/deploy/helm/k8s_apps.yaml
+++ b/deploy/helm/k8s_apps.yaml
@@ -61,3 +61,12 @@ charts:
     location: ./deploy/helm/charts
     enabled: "${env:KYVERNO_POLICIES_ENABLED}"
     values_template: deploy/helm/values/kyverno-policies.yaml
+
+  - name: aws-ebs-csi-driver
+    namespace: ${env:AWS_EBS_CSI_DRIVER_NAMESPACE}
+    location: aws-ebs-csi-driver
+    enabled: "${env:AWS_EBS_CSI_DRIVER_ENABLED}"
+    repo: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+    values_template: deploy/helm/values/aws-ebs-csi-driver.yaml
+    version: 2.41.0
+

--- a/deploy/helm/k8s_apps.yaml
+++ b/deploy/helm/k8s_apps.yaml
@@ -69,4 +69,3 @@ charts:
     repo: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
     values_template: deploy/helm/values/aws-ebs-csi-driver.yaml
     version: 2.41.0
-

--- a/deploy/helm/values/aws-ebs-csi-driver.yaml
+++ b/deploy/helm/values/aws-ebs-csi-driver.yaml
@@ -1,0 +1,5 @@
+controller:
+  serviceAccount:
+    name: "${env:AWS_EBS_CSI_DRIVER_SERVICE_ACCOUNT_NAME}"
+    annotations:
+      eks.amazonaws.com/role-arn: "${env:TFOUT_aws_ebs_csi_driver_role_arn}"


### PR DESCRIPTION
#### 📲 What

added ebs csi volume driver chart

updated cluster to t3.medium, we have too many pods now and t3.small doesn't have enough pod capacity and resources

#### 🤔 Why

Facilitates the use of Amazon EBS as persistent storage in Kubernetes environments, enhancing storage capabilities with minimal effort

#### 🛠 How

Added CSI driver as a helm chart, creating the IRSA in terraform

#### 👀 Evidence
