### PR TITLE
chore(dependabot): group terraform updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,29 @@
 version: 2
 updates:
   - package-ecosystem: terraform
-    directory: "/deploy/aws/pre-infra"
+    directories:
+      - "/deploy/aws/pre-infra"
+      - "/deploy/aws/infra"
     schedule:
       interval: weekly
       day: monday
       timezone: Europe/London
+    cooldown:
+      default-days: 5
     open-pull-requests-limit: 10
     rebase-strategy: disabled
-
-  - package-ecosystem: terraform
-    directory: "/deploy/aws/infra"
-    schedule:
-      interval: weekly
-      day: monday
-      timezone: Europe/London
-    open-pull-requests-limit: 10
-    rebase-strategy: disabled
+    reviewers:
+      - Ensono/dependency-management
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      terraform:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        group-by: dependency-name
+      terraform-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "cooldown"
+    ]
+}


### PR DESCRIPTION
## Summary
- group Terraform Dependabot updates across both infrastructure directories
- add a five-day cooldown before version update PRs are opened
- force Dependabot commit and PR titles to use a CI-compliant conventional commit prefix
- add the VS Code workspace dictionary entry for cooldown

## Testing
- editor validation for .github/dependabot.yml
- editor validation for .vscode/settings.json

No ticket was provided.